### PR TITLE
Button layout: Increase width

### DIFF
--- a/res/layout-land/countdown.xml
+++ b/res/layout-land/countdown.xml
@@ -75,22 +75,28 @@
 
             <LinearLayout
                 android:id="@+id/LinearLayout01"
-                android:layout_width="wrap_content"
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content" >
 
                 <Button
                     android:id="@+id/startButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="0dp" android:layout_weight=".25"
+                    android:layout_height="60dp"
                     android:text="@string/start_stop" >
                 </Button>
 
                 <Button
                     android:id="@+id/refreshButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="0dp" android:layout_weight=".25"
+                    android:layout_height="60dp"
                     android:text="@string/refresh" >
                 </Button>
+
+                <TextView
+                    android:layout_width="0dp" android:layout_weight=".5"
+                    android:layout_height="60dp"
+                    android:text=""
+                    />
             </LinearLayout>
 
             <LinearLayout

--- a/res/layout-land/main.xml
+++ b/res/layout-land/main.xml
@@ -1,32 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Main Anstop layout, landscape mode. Hour and mm:ss:d time on same line. -->
+<!-- Left column (45% of width) is hh:mm:ss:d and buttons, right (55%) is laps textview. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:id="@+id/stopwatchLayout">
+
+    <!-- TODO Code refers to both stopwatchLayout and mainLayout; see Anstop.setupGesture -->
     <LinearLayout
 		android:id="@+id/mainLayout"
 		android:layout_height="fill_parent"
 		android:layout_width="fill_parent"
-		android:orientation="vertical">
+		android:orientation="horizontal">
 
-		<LinearLayout android:id="@+id/LinearLayout02" android:layout_width="wrap_content" android:layout_height="wrap_content">
-			<TextView android:layout_width="wrap_content" android:layout_height="fill_parent" android:id="@+id/hourView" android:text="0" />
-			<TextView android:id="@+id/hourLabelView" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/hour" />
-			<TextView android:layout_width="3sp" android:layout_height="wrap_content" android:text="" /><!-- spacer; 3sp is scaled with user's text preferences -->
-			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/minView" android:text="00" />
-			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text=":" android:id="@+id/sepView1" />
-			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/secondsView" android:text="00" />
-			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text=":" android:id="@+id/sepView2" />
-			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/dsecondsView" android:text="0" />
-		</LinearLayout>
-
-		<!-- 3 buttons together fill half of landscape width; height also increased -->
 		<LinearLayout android:layout_margin="0dp"
-		    android:layout_width="fill_parent" android:layout_height="fill_parent">
+			android:layout_width="0dp" android:layout_weight=".45" android:layout_height="wrap_content"
+			android:orientation="vertical">
+
+			<!-- hh hours mm:ss:d -->
+			<LinearLayout android:id="@+id/LinearLayout02"
+				android:layout_width="wrap_content" android:layout_height="wrap_content" >
+
+				<TextView android:layout_width="wrap_content" android:layout_height="fill_parent"
+				    android:id="@+id/hourView" android:text="0" />
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/hourLabelView" android:text="@string/hour" />
+				<!-- spacer; 3sp is scaled with user's text preferences -->
+				<TextView android:layout_width="3sp" android:layout_height="wrap_content" android:text="" />
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/minView" android:text="00" />
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/sepView1" android:text=":" />
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/secondsView" android:text="00" />
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/sepView2" android:text=":" />
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/dsecondsView" android:text="0" />
+			</LinearLayout>
+
+			<!-- 3 buttons together fill half of landscape width; height also increased -->
 			<LinearLayout android:id="@+id/LinearLayout01"
-			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="wrap_content">
+				android:layout_margin="0dp" android:padding="0dp"
+				android:layout_width="fill_parent" android:layout_height="wrap_content"
+				android:gravity="top" >
+
 				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".34"
 				    android:id="@+id/startButton" android:text="@string/start_stop" />
 				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
@@ -34,13 +53,15 @@
 				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
 				    android:id="@+id/lapButton" android:text="@string/lap" />
 			</LinearLayout>
-			<!-- laps to right of time fields and buttons -->
-			<ScrollView android:id="@+id/lapScrollView"
-			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="fill_parent">
-				<TextView android:id="@+id/lapView"
-				    android:layout_width="fill_parent" android:layout_height="wrap_content"
-				    android:text="@string/laps" />
-			</ScrollView>
+
 		</LinearLayout>
+
+		<!-- laps to right of time fields and buttons -->
+		<ScrollView android:id="@+id/lapScrollView"
+			android:layout_width="0dp" android:layout_weight=".55" android:layout_height="fill_parent" >
+			<TextView android:id="@+id/lapView"
+			    android:layout_width="fill_parent" android:layout_height="wrap_content"
+			    android:text="@string/laps" />
+		</ScrollView>
 	</LinearLayout>
 </LinearLayout>

--- a/res/layout-land/main.xml
+++ b/res/layout-land/main.xml
@@ -24,7 +24,7 @@
 
 		<!-- 3 buttons together fill half of landscape width; height also increased -->
 		<LinearLayout android:layout_margin="0dp"
-		    android:layout_width="fill_parent" android:layout_height="wrap_content">
+		    android:layout_width="fill_parent" android:layout_height="fill_parent">
 			<LinearLayout android:id="@+id/LinearLayout01"
 			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="wrap_content">
 				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".34"
@@ -34,16 +34,13 @@
 				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
 				    android:id="@+id/lapButton" android:text="@string/lap" />
 			</LinearLayout>
-			<LinearLayout
-			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="wrap_content">
-				<!-- blank; consider moving laps over here? -->
-				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" />
-			</LinearLayout>
+			<!-- laps to right of time fields and buttons -->
+			<ScrollView android:id="@+id/lapScrollView"
+			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="fill_parent">
+				<TextView android:id="@+id/lapView"
+				    android:layout_width="fill_parent" android:layout_height="wrap_content"
+				    android:text="@string/laps" />
+			</ScrollView>
 		</LinearLayout>
-
-		<ScrollView android:id="@+id/lapScrollView" android:layout_width="fill_parent" android:layout_height="fill_parent">
-			<TextView android:layout_width="fill_parent" android:layout_height="wrap_content" android:id="@+id/lapView" android:text="@string/laps" />
-		</ScrollView>
-
 	</LinearLayout>
 </LinearLayout>

--- a/res/layout-land/main.xml
+++ b/res/layout-land/main.xml
@@ -22,10 +22,23 @@
 			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/dsecondsView" android:text="0" />
 		</LinearLayout>
 
-		<LinearLayout android:id="@+id/LinearLayout01" android:layout_width="wrap_content" android:layout_height="wrap_content">
-			<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/startButton" android:text="@string/start_stop" />
-			<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/resetButton" android:text="@string/reset" />
-			<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/lapButton" android:text="@string/lap" />
+		<!-- 3 buttons together fill half of landscape width; height also increased -->
+		<LinearLayout android:layout_margin="0dp"
+		    android:layout_width="fill_parent" android:layout_height="wrap_content">
+			<LinearLayout android:id="@+id/LinearLayout01"
+			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="wrap_content">
+				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".34"
+				    android:id="@+id/startButton" android:text="@string/start_stop" />
+				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
+				    android:id="@+id/resetButton" android:text="@string/reset" />
+				<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
+				    android:id="@+id/lapButton" android:text="@string/lap" />
+			</LinearLayout>
+			<LinearLayout
+			    android:layout_width="0dp" android:layout_weight=".5" android:layout_height="wrap_content">
+				<!-- blank; consider moving laps over here? -->
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" />
+			</LinearLayout>
 		</LinearLayout>
 
 		<ScrollView android:id="@+id/lapScrollView" android:layout_width="fill_parent" android:layout_height="fill_parent">

--- a/res/layout/countdown.xml
+++ b/res/layout/countdown.xml
@@ -28,22 +28,12 @@
 		</LinearLayout>
 
 
-
-<LinearLayout android:id="@+id/LinearLayout01" android:layout_width="wrap_content" android:layout_height="wrap_content"><Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/startButton" android:text="@string/start_stop"></Button>
-
-<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/refreshButton" android:text="@string/refresh"></Button>
-
-
-
-
-</LinearLayout>
-
-
-
-
-
-
-
+	<LinearLayout android:id="@+id/LinearLayout01" android:layout_width="fill_parent" android:layout_height="wrap_content">
+		<Button android:layout_width="0dp" android:layout_weight=".5" android:layout_height="60dp"
+		    android:id="@+id/startButton" android:text="@string/start_stop" />
+		<Button android:layout_width="0dp" android:layout_weight=".5" android:layout_height="60dp"
+		    android:id="@+id/refreshButton" android:text="@string/refresh" />
+	</LinearLayout>
 
 
 <LinearLayout android:id="@+id/LinearLayout04" android:layout_width="wrap_content" android:layout_height="wrap_content">

--- a/res/layout/countdown.xml
+++ b/res/layout/countdown.xml
@@ -9,17 +9,18 @@
     android:orientation="vertical"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent" >
+    <!-- TODO Code refers to both countDownLayout and mainLayout; see Anstop.setupGesture -->
     <LinearLayout
 		android:id="@+id/mainLayout"
 		android:layout_height="fill_parent"
 		android:layout_width="fill_parent"
 		android:orientation="vertical">
 
-		<LinearLayout android:id="@+id/LinearLayout03" android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="horizontal" >
-			<TextView android:layout_width="fill_parent" android:layout_height="wrap_content" android:id="@+id/hourView" android:text="0" />
-			<TextView android:id="@+id/TextView03" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/hour" />
-		</LinearLayout>
 		<LinearLayout android:id="@+id/LinearLayout02" android:layout_width="wrap_content" android:layout_height="wrap_content">
+			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/hourView" android:text="0" />
+			<TextView android:id="@+id/TextView03" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/hour" />
+			<!-- spacer; 3sp is scaled with user's text preferences -->
+			<TextView android:layout_width="3sp" android:layout_height="wrap_content" android:text="" />
 			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/minView" android:text="00" />
 			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text=":" android:id="@+id/sepView1" />
 			<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/secondsView" android:text="00" />

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -24,10 +24,14 @@
 			</LinearLayout>
 		</RelativeLayout>
 
-		<LinearLayout android:id="@+id/LinearLayout01" android:layout_width="wrap_content" android:layout_height="wrap_content">
-			<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/startButton" android:text="@string/start_stop" />
-			<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/resetButton" android:text="@string/reset" />
-			<Button android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/lapButton" android:text="@string/lap" />
+		<!-- 3 buttons together fill activity width; height also increased -->
+		<LinearLayout android:id="@+id/LinearLayout01" android:layout_width="fill_parent" android:layout_height="wrap_content">
+			<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".34"
+			    android:id="@+id/startButton" android:text="@string/start_stop" />
+			<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
+			    android:id="@+id/resetButton" android:text="@string/reset" />
+			<Button android:layout_width="0dp" android:layout_height="60dp" android:layout_weight=".33"
+			    android:id="@+id/lapButton" android:text="@string/lap" />
 		</LinearLayout>
 
 		<ScrollView android:id="@+id/lapScrollView" android:layout_width="fill_parent" android:layout_height="fill_parent">

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -4,18 +4,24 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:id="@+id/stopwatchLayout">
+    <!-- TODO Code refers to both stopwatchLayout and mainLayout; see Anstop.setupGesture -->
     <LinearLayout
 		android:id="@+id/mainLayout"
 		android:layout_height="fill_parent"
 		android:layout_width="fill_parent"
 		android:orientation="vertical">
 
-		<LinearLayout android:id="@+id/LinearLayout03" android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="horizontal" >
-			<TextView android:layout_width="fill_parent" android:layout_height="wrap_content" android:id="@+id/hourView" android:text="0" />
-			<TextView android:id="@+id/hourLabelView" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/hour" />
-		</LinearLayout>
 		<RelativeLayout android:id="@+id/RelativeLayout01" android:layout_width="wrap_content" android:layout_height="wrap_content">
 			<LinearLayout android:id="@+id/LinearLayout02" android:layout_width="wrap_content" android:layout_height="wrap_content">
+				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+				    android:id="@+id/hourView" android:text="0" />
+				<TextView
+				    android:id="@+id/hourLabelView"
+				    android:layout_width="wrap_content"
+				    android:layout_height="wrap_content"
+				    android:text="@string/hour" />
+				<!-- spacer; 3sp is scaled with user's text preferences -->
+				<TextView android:layout_width="3sp" android:layout_height="wrap_content" android:text="" />
 				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/minView" android:text="00" />
 				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text=":" android:id="@+id/sepView1" />
 				<TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:id="@+id/secondsView" android:text="00" />

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -11,7 +11,7 @@
 <string name="refresh">Recargar</string>
 <string name="refresh_during_count">¡No se puede recargar contando!</string>
 <string name="start_stop">Iniciar/Parar</string>
-<string name="lap">-  ¡Vuelta!  -</string>
+<string name="lap">¡Vuelta!</string>
 <string name="laps">Vueltas:</string>
 <string name="about">Acerca de</string>
 <string name="stop">Cronómetro</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -12,7 +12,7 @@
 <string name="refresh">Freskatu</string>
 <string name="refresh_during_count">Ezin da freskatu martxan dagoela!</string>
 <string name="start_stop">Hasi/Gelditu</string>
-<string name="lap">-  Bira!  -</string>
+<string name="lap">Bira!</string>
 <string name="laps">Birak:</string>
 <string name="about">Honi buruz</string>
 <string name="stop">Kronometroa</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11,7 +11,7 @@
 <string name="refresh">Refresh</string>
 <string name="refresh_during_count">Cannot refresh during count!</string>
 <string name="start_stop">Start/Stop</string>
-<string name="lap">-  Lap!  -</string>
+<string name="lap">Lap!</string>
 <string name="laps">Laps:</string>
 <string name="about">About</string>
 <string name="stop">Stopwatch</string>


### PR DESCRIPTION
Hi MJ,

I've implemented this feature request from landroni: "It would be useful if the buttons in Anstop were wider (and maybe even bigger, as in higher). Making them 1/3 of the screen each would be one solution, for instance."

I made them 1/3 portrait width, and 1/6 landscape width (3 buttons is ~half of landscape; the other half is the lap text scroll).

Original request issue is: https://github.com/jdmonin/anstop/issues/1

Thanks,
-Jeremy
